### PR TITLE
Rename wrong section name ('bell' to 'body')

### DIFF
--- a/lib/saxophone_infochart_back_web/controllers/structure_controller.ex
+++ b/lib/saxophone_infochart_back_web/controllers/structure_controller.ex
@@ -25,7 +25,7 @@ defmodule SaxophoneInfochartBackWeb.StructureController do
     conn |> send_resp(200, data)
   end
 
-  def bell(conn, _params) do
+  def body(conn, _params) do
     data = """
       The sound vibrates within the body and is amplified. By holding down the keys,
       which are located on the body, you change the length of the air column to create

--- a/lib/saxophone_infochart_back_web/router.ex
+++ b/lib/saxophone_infochart_back_web/router.ex
@@ -11,7 +11,7 @@ defmodule SaxophoneInfochartBackWeb.Router do
     get "/reed",        StructureController, :reed
     get "/mouthpiece",  StructureController, :mouthpiece
     get "/neck",        StructureController, :neck
-    get "/bell",        StructureController, :bell
+    get "/body",        StructureController, :body
     get "/octave_pin",  StructureController, :octave_pin
     get "/neck_strap",  StructureController, :neck_strap
   end

--- a/test/saxophone_infochart_back_web/controllers/application_controller_test.exs
+++ b/test/saxophone_infochart_back_web/controllers/application_controller_test.exs
@@ -37,10 +37,10 @@ defmodule SaxophoneInfochartBackWeb.StructureControllerTest do
     assert test_conn.status == 200
   end
 
-  test "GET /api/bell returns success", %{conn: conn} do
+  test "GET /api/body returns success", %{conn: conn} do
     test_conn = conn
     |> put_req_header("accept", "application/json")
-    |> get("/api/bell")
+    |> get("/api/body")
 
     assert test_conn.resp_body == """
       The sound vibrates within the body and is amplified. By holding down the keys,


### PR DESCRIPTION
Hi,
This PR fixes a wrong sax part. The "bell" was supposed to be called "body" given its description.